### PR TITLE
Use display_name instead of name

### DIFF
--- a/roles/infra/tasks/create_vm.yml
+++ b/roles/infra/tasks/create_vm.yml
@@ -1,7 +1,7 @@
   - name: Create instances
     local_action:
       module: cs_instance
-      name: "nginx-{{ item }}"
+      display_name: "nginx-{{ item }}"
       template: "{{ template }}"
       service_offering: "{{ instance_type }}"
       ssh_key: "{{ ssh_key }}"


### PR DESCRIPTION
"name" has to be unique among all users (due to the use of CS basic
networking model). This is not the case for "display_name".